### PR TITLE
Fix release workflow error

### DIFF
--- a/.changeset/dirty-ducks-allow.md
+++ b/.changeset/dirty-ducks-allow.md
@@ -2,4 +2,4 @@
 '@thisismissem/adonisjs-respond-with': patch
 ---
 
-Initial pre-release
+Prepare for initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thisismissem/adonisjs-respond-with",
-  "description": "",
+  "description": "A small plugin for Adonis.js to make responding with different content-types easier.",
   "version": "0.0.0",
   "engines": {
     "node": ">=20.6.0"
@@ -61,7 +61,13 @@
   "peerDependencies": {
     "@adonisjs/core": "^6.2.0"
   },
-  "author": "Emelia Smith",
+  "contributors": [
+    {
+      "name": "Emelia Smith",
+      "url": "https://github.com/thisismissem"
+    }
+  ],
+  "repository": "github:thisismissem/adonisjs-respond-with",
   "license": "MIT",
   "keywords": [
     "adonisjs",


### PR DESCRIPTION
I think it was choking on the `author` property in the `package.json`, the error was:

```
> changeset version && npm run prettier:write CHANGELOG.md && git add package.json CHANGELOG.md
(node:1918) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
The following error was encountered while generating changelog entries
We have escaped applying the changesets, and no files should have been affected
🦋  error TypeError: Cannot read properties of null (reading 'author')
🦋  error     at Object.getInfo (/home/runner/work/adonisjs-respond-with/adonisjs-respond-with/node_modules/@changesets/get-github-info/dist/changesets-get-github-info.cjs.js:233:12)
🦋  error     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
🦋  error     at async /home/runner/work/adonisjs-respond-with/adonisjs-respond-with/node_modules/@changesets/changelog-github/dist/changesets-changelog-github.cjs.js:123:13
🦋  error     at async Object.getReleaseLine (/home/runner/work/adonisjs-respond-with/adonisjs-respond-with/node_modules/@changesets/changelog-github/dist/changesets-changelog-github.cjs.js:99:19)
🦋  error     at async Promise.all (index 0)
🦋  error     at async generateChangesForVersionTypeMarkdown (/home/runner/work/adonisjs-respond-with/adonisjs-respond-with/node_modules/@changesets/apply-release-plan/dist/changesets-apply-release-plan.cjs.js:141:22)
🦋  error     at async getChangelogEntry (/home/runner/work/adonisjs-respond-with/adonisjs-respond-with/node_modules/@changesets/apply-release-plan/dist/changesets-apply-release-plan.cjs.js:197:179)
🦋  error     at async /home/runner/work/adonisjs-respond-with/adonisjs-respond-with/node_modules/@changesets/apply-release-plan/dist/changesets-apply-release-plan.cjs.js:449:21
🦋  error     at async Promise.all (index 0)
🦋  error     at async Object.applyReleasePlan [as default] (/home/runner/work/adonisjs-respond-with/adonisjs-respond-with/node_modules/@changesets/apply-release-plan/dist/changesets-apply-release-plan.cjs.js:332:31)
```