### PR TITLE
Remove unnecessary files from package releases

### DIFF
--- a/.changeset/violet-wasps-tell.md
+++ b/.changeset/violet-wasps-tell.md
@@ -1,0 +1,5 @@
+---
+'@thisismissem/adonisjs-respond-with': patch
+---
+
+Remove unnecessary files from package releases

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+build/bin
+build/tests


### PR DESCRIPTION
Previously bin and tests were included, but these files are only relevant during development and make no sense to include in the package.