### PR TITLE
Fix unnecessary files not being correctly ignored

### DIFF
--- a/.changeset/tidy-spoons-judge.md
+++ b/.changeset/tidy-spoons-judge.md
@@ -1,0 +1,7 @@
+---
+'@thisismissem/adonisjs-respond-with': patch
+---
+
+Fix issue with necessary files being in package
+
+The previous change using `.npmignore` didn't work because of the `files` directive in the `package.json`

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-build/bin
-build/tests

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "type": "module",
   "files": [
     "build/",
-    "build/stubs"
+    "build/stubs",
+    "!build/bin",
+    "!build/tests"
   ],
   "exports": {
     ".": "./build/index.js",


### PR DESCRIPTION
The previous change using `.npmignore` didn't work because of the `files` directive in the `package.json`