### PR TITLE
Fix error with missing accepts header

### DIFF
--- a/.changeset/proud-pillows-itch.md
+++ b/.changeset/proud-pillows-itch.md
@@ -1,0 +1,5 @@
+---
+'@thisismissem/adonisjs-respond-with': patch
+---
+
+Fix issue with missing Accept header triggering a random handler

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,14 @@ Response.macro('negotiate', async function <
 
   const bestMatch = this.ctx!.request.accepts(acceptedTypes)
 
-  this.ctx?.logger.trace({ respondWith: { acceptedTypes, bestMatch, matchers: matcherNames } })
+  this.ctx?.logger.trace({
+    respondWith: {
+      acceptHeader: this.ctx!.request.header('accept'),
+      acceptedTypes,
+      bestMatch,
+      matchers: matcherNames,
+    },
+  })
 
   // If we support the matched content-type is known, execute it:
   if (bestMatch && acceptedTypes.includes(bestMatch)) {

--- a/src/negotiator.ts
+++ b/src/negotiator.ts
@@ -49,7 +49,7 @@ export class Negotiator {
   }
 
   getAcceptedTypes(matcherNames: string[]): string[] {
-    const acceptedTypes: string[] = []
+    const acceptedTypes: string[] = ['*/*']
     for (const name of matcherNames) {
       const handlerContentTypes = this.handlerTypes.get(name)
       if (handlerContentTypes) {

--- a/tests/extension.spec.ts
+++ b/tests/extension.spec.ts
@@ -51,6 +51,29 @@ test.group('Request respond_with', () => {
     assert.equal(ctx.response.getStatus(), 406, 'Should return 406 unprocessable')
   })
 
+  test('without Accept header', async ({ assert }) => {
+    const { testUtils } = await setupApp({
+      rcFileContents: {
+        providers: () => import('../providers/respond_with.js'),
+      },
+    })
+
+    const ctx = await testUtils.createHttpContext()
+
+    // Explicitly don't set ctx.request.request.headers['accept']
+
+    var callback = sinon.fake()
+
+    await ctx.response.negotiate({
+      json: () => {
+        return callback()
+      },
+    })
+
+    assert.equal(callback.callCount, 0, 'Did not invoke the json handler')
+    assert.equal(ctx.response.getStatus(), 406, 'Should return 406 unprocessable')
+  })
+
   test('Additional Types with unsupported type that would require an additional type', async ({
     assert,
   }) => {

--- a/tests/extension.spec.ts
+++ b/tests/extension.spec.ts
@@ -368,7 +368,7 @@ test.group('Request respond_with', () => {
 
     const ctx = await testUtils.createHttpContext()
 
-    ctx.request.request.headers['accept'] = 'application/api.v1+json, application/json'
+    ctx.request.request.headers['accept'] = 'application/json, application/api.v1+json'
 
     var jsonCallback = sinon.fake()
     var htmlCallback = sinon.fake()
@@ -385,7 +385,7 @@ test.group('Request respond_with', () => {
     assert.isTrue(jsonCallback.calledOnce, 'Invoked the json handler for a json-ld request')
     assert.equal(
       jsonCallback.firstCall.args[0],
-      'application/api.v1+json',
+      'application/json',
       'Passes the matched content-type to the handler'
     )
     assert.equal(htmlCallback.callCount, 0, 'Should not invoke the html handler')


### PR DESCRIPTION
Without the `*/*` being supplied to `accepts()`, the method ends up returning just the first accepted type from the list of acceptable types. This result in strange behavior as described in #21 