### PR TITLE
Update mime-types in package.json

### DIFF
--- a/.changeset/three-cobras-rhyme.md
+++ b/.changeset/three-cobras-rhyme.md
@@ -1,0 +1,7 @@
+---
+'@thisismissem/adonisjs-respond-with': patch
+---
+
+Update mime-types peer dependency to 3.0.1
+
+Whilst this update does drop node.js 18 support, this package never officially supported node.js 18, so that is a non-breaking change for us.

--- a/.changeset/three-cobras-rhyme.md
+++ b/.changeset/three-cobras-rhyme.md
@@ -4,4 +4,4 @@
 
 Update mime-types peer dependency to 3.0.1
 
-Whilst this update does drop node.js 18 support, this package never officially supported node.js 18, so that is a non-breaking change for us.
+Whilst this update does drop node.js 18 support, this package never officially supported node.js 18, so that is a non-breaking change for us. We've also updated some development dependencies.

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "@adonisjs/core": "^6.2.0",
-    "mime-types": "^2.1.35"
+    "mime-types": "^3.0.1"
   },
   "contributors": [
     {


### PR DESCRIPTION
This is technically out of sync with Adonis, however, 3.0.0 was only a major version bump because it dropped support for node.js 18: https://github.com/jshttp/mime-types/blob/master/HISTORY.md#300--2024-08-31