### PR TITLE
Update to adonisjs v6 to v7

### DIFF
--- a/.changeset/spicy-pugs-hang.md
+++ b/.changeset/spicy-pugs-hang.md
@@ -1,0 +1,23 @@
+---
+'@thisismissem/adonisjs-respond-with': major
+---
+
+Upgrade to AdonisJS v7
+
+Updates the following packages to their latest (v7-compatible) versions:
+
+- `@adonisjs/assembler`
+- `@adonisjs/core`
+- `@adonisjs/eslint-config`
+- `@adonisjs/prettier-config`
+- `@adonisjs/tsconfig`
+
+**Breaking changes:**
+
+- Bumps `@adonisjs/core` peer dependency from `^6.2.0` to `^7.x`
+- Requires Node.js `>=24.0.0` (previously `>=20.6.0`)
+- Renamed `Request` to `HttpRequest` and `Response` to `HttpResponse` to match the AdonisJS v7 interface naming
+
+**Internal changes:**
+
+- Replaced `ts-node` with `@poppinss/ts-exec`, the TypeScript JIT compiler now used by AdonisJS v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [24, 26]
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small plugin for Adonis.js to make responding with different content-types eas
 
 ## API
 
-This package extends the Request class to add a respondWith method, which takes a record of key-value pairs where the key is the accepted content-type, and the value is a callable function that handles the response.
+This package extends the HttpRequest class to add a respondWith method, which takes a record of key-value pairs where the key is the accepted content-type, and the value is a callable function that handles the response.
 
 ## Example Usage
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A small plugin for Adonis.js to make responding with different content-types easier.",
   "version": "3.0.0",
   "engines": {
-    "node": ">=20.6.0"
+    "node": ">=24.0.0"
   },
   "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b",
   "main": "./build/index.js",
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@adonisjs/assembler": "^8.4.0",
-    "@adonisjs/core": "^7.3.5",
+    "@adonisjs/core": "^7.0.0",
     "@adonisjs/eslint-config": "^3.1.0",
     "@adonisjs/prettier-config": "^1.5.0",
     "@adonisjs/tsconfig": "^2.0.0",
@@ -66,7 +66,7 @@
     "yalc": "^1.0.0-pre.53"
   },
   "peerDependencies": {
-    "@adonisjs/core": "^7.3.5",
+    "@adonisjs/core": "^7.0.0",
     "mime-types": "^3.0.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@japa/assert": "^4.0.1",
     "@japa/file-system": "^2.3.2",
     "@japa/runner": "^4.2.0",
-    "@swc/core": "^1.10.15",
+    "@poppinss/ts-exec": "^1.4.4",
     "@types/mime-types": "^3.0.0",
     "@types/negotiator": "^0.6.4",
     "@types/node": "^24.0.8",
@@ -62,7 +62,6 @@
     "pino-pretty": "^13.1.2",
     "prettier": "^3.5.0",
     "sinon": "^21.0.0",
-    "ts-node-maintained": "^10.9.6",
     "typescript": "^5.7.3",
     "yalc": "^1.0.0-pre.53"
   },

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@adonisjs/assembler": "^7.7.0",
-    "@adonisjs/core": "^6.12.0",
-    "@adonisjs/eslint-config": "^2.0.0-beta.7",
-    "@adonisjs/prettier-config": "^1.4.0",
-    "@adonisjs/tsconfig": "^1.4.0",
+    "@adonisjs/assembler": "^8.4.0",
+    "@adonisjs/core": "^7.3.5",
+    "@adonisjs/eslint-config": "^3.1.0",
+    "@adonisjs/prettier-config": "^1.5.0",
+    "@adonisjs/tsconfig": "^2.0.0",
     "@arethetypeswrong/cli": "^0.18.1",
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.12",
@@ -67,7 +67,7 @@
     "yalc": "^1.0.0-pre.53"
   },
   "peerDependencies": {
-    "@adonisjs/core": "^6.2.0",
+    "@adonisjs/core": "^7.3.5",
     "mime-types": "^3.0.1"
   },
   "dependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,20 +1,20 @@
-import { Response, Request } from '@adonisjs/core/http'
+import { HttpResponse, HttpRequest } from '@adonisjs/core/http'
 import type { ResponseMatchers, NegotiateOptions } from './types.js'
 import { AcceptNegotiator } from './acceptor.js'
 import { RuntimeException } from '@adonisjs/core/exceptions'
 import Negotiator from 'negotiator'
 
-Request.getter(
+HttpRequest.getter(
   'negotiator',
-  function (this: Request): Negotiator {
+  function (this: HttpRequest): Negotiator {
     return new Negotiator(this.request)
   },
   true
 )
 
-Response.macro('negotiate', async function <
+HttpResponse.macro('negotiate', async function <
   T extends ResponseMatchers,
->(this: Response, matchers: T, options?: NegotiateOptions<T>): Promise<void> {
+>(this: HttpResponse, matchers: T, options?: NegotiateOptions<T>): Promise<void> {
   const acceptor = await this.ctx!.containerResolver.make(AcceptNegotiator)
   const negotiator = this.ctx!.request.negotiator
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,11 +16,11 @@ export interface NegotiateOptions<MatcherNames> {
 }
 
 declare module '@adonisjs/core/http' {
-  interface Request {
+  interface HttpRequest {
     negotiator: Negotiator
   }
 
-  interface Response {
+  interface HttpResponse {
     negotiate<T extends ResponseMatchers>(matchers: T): any
     negotiate<T extends ResponseMatchers>(matchers: T, options: NegotiateOptions<keyof T>): any
   }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 /**
  * Register hook to process TypeScript files using ts-node
  */
-import 'ts-node-maintained/register/esm'
+import '@poppinss/ts-exec'
 
 /**
  * Import ace console entrypoint

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 /**
- * Register hook to process TypeScript files using ts-node
+ * Register hook to process TypeScript files using @poppinss/ts-exec
  */
 import '@poppinss/ts-exec'
 


### PR DESCRIPTION
## Upgrade AdonisJS v6 → v7

Updates the following packages to their latest (v7-compatible) versions:
- `@adonisjs/assembler`
- `@adonisjs/core`
- `@adonisjs/eslint-config`
- `@adonisjs/prettier-config`
- `@adonisjs/tsconfig`

**Changes:**
- Replaced `ts-node` with `@poppinss/ts-exec`, the TypeScript JIT compiler now used by AdonisJS v7
- Renamed `Request` → `HttpRequest` and `Response` → `HttpResponse` to match the AdonisJS v7 interface naming

Closes #52 