### PR TITLE
fix: replace type 'any' with dynamic types to reflect negotiated values

### DIFF
--- a/.changeset/sharp-lamps-juggle.md
+++ b/.changeset/sharp-lamps-juggle.md
@@ -1,0 +1,7 @@
+---
+'@thisismissem/adonisjs-respond-with': patch
+---
+
+Improve return type of `response.negotiate`
+
+Changed the return type from `any` to `ReturnType<T[keyof T]>` to accurately reflect the actual return type of the handlers passed to `negotiate`.

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,8 +21,11 @@ declare module '@adonisjs/core/http' {
   }
 
   interface HttpResponse {
-    negotiate<T extends ResponseMatchers>(matchers: T): any
-    negotiate<T extends ResponseMatchers>(matchers: T, options: NegotiateOptions<keyof T>): any
+    negotiate<T extends ResponseMatchers>(matchers: T): ReturnType<T[keyof T]>
+    negotiate<T extends ResponseMatchers>(
+      matchers: T,
+      options: NegotiateOptions<keyof T>
+    ): ReturnType<T[keyof T]>
   }
 }
 


### PR DESCRIPTION
Improve return type of `response.negotiate`

Changed the return type from `any` to `ReturnType<T[keyof T]>` to accurately reflect the actual return type of the handlers passed to `negotiate`.